### PR TITLE
Expire the cache in Redis storage

### DIFF
--- a/croquemort/decorators.py
+++ b/croquemort/decorators.py
@@ -58,5 +58,6 @@ def cache_page(duration):
                 return Response(cached['content'], mimetype='text/html')
         response = wrapped(*args, **kwargs)
         instance.storage.set_cache(key, response.response[0])
+        instance.storage.expire_cache(key, duration)
         return response
     return wrapper

--- a/croquemort/migrations.py
+++ b/croquemort/migrations.py
@@ -18,7 +18,7 @@ class MigrationsService(object):
     def delete_urls_for(self, domain):
         log('Deleting URLs for domain {domain}'.format(domain=domain))
         for url_hash, data in self.storage.get_all_urls():
-            if urlparse(data['url']).netloc == domain:
+            if data and urlparse(data['url']).netloc == domain:
                 self.storage.delete_url(url_hash)
 
     @rpc

--- a/croquemort/storages.py
+++ b/croquemort/storages.py
@@ -122,3 +122,6 @@ class RedisStorage(DependencyProvider):
         self.database.hset(key, 'timestamp',
                            str_to_bytes(datetime.now().isoformat()))
         self.database.hset(key, 'content', str_to_bytes(content))
+
+    def expire_cache(self, key, duration):
+        self.database.expire(key, duration)


### PR DESCRIPTION
Otherwise it piles up and given the size of the content cached (the whole page) it ends up with the Redis database growing indefinitely and quite fast.