### PR TITLE
Redirect handling

### DIFF
--- a/tests/services/test_crawler.py
+++ b/tests/services/test_crawler.py
@@ -1,7 +1,15 @@
+from collections import namedtuple
+
 from nameko.testing.services import entrypoint_waiter, replace_dependencies
+from nameko.testing.utils import get_extension
 from nameko.standalone.events import event_dispatcher
 
 from croquemort.crawler import CrawlerService
+from croquemort.storages import RedisStorage
+from croquemort.tools import generate_hash_for
+
+DummyResponse = namedtuple('res',
+                           ['url', 'status_code', 'headers', 'history'])
 
 
 def test_crawling_url(container_factory, rabbit_config, web_container_config):
@@ -36,3 +44,42 @@ def test_crawling_group(
     assert storage.store_metadata.call_count == 1
     # fired 'url_crawled'
     assert dispatch_dep.call_count == 1
+
+
+def test_store_redirect_metadata(
+        container_factory, rabbit_config, web_container_config):
+    res = DummyResponse('http://redirect-done.com', 200, None,
+                        [DummyResponse('http://redirecting.com', 301, None,
+                         None)])
+    crawler_container = container_factory(CrawlerService, web_container_config)
+    crawler_container.start()
+    storage = get_extension(crawler_container, RedisStorage)
+    storage.store_url('http://redirect.com')
+    storage.store_metadata('http://redirect.com', res)
+    stored = storage.get_url(generate_hash_for('url', 'http://redirect.com'))
+    assert stored['redirect-url'] == 'http://redirecting.com'
+    assert stored['redirect-status-code'] == '301'
+    assert stored['checked-url'] == 'http://redirect.com'
+    assert stored['final-url'] == 'http://redirect-done.com'
+    assert stored['final-status-code'] == '200'
+    assert stored.get('url') is None
+    assert stored.get('status') is None
+
+
+def test_store_no_redirect(
+        container_factory, rabbit_config, web_container_config):
+    res = DummyResponse('http://no-redirect.com', 200, None, [])
+    crawler_container = container_factory(CrawlerService, web_container_config)
+    crawler_container.start()
+    storage = get_extension(crawler_container, RedisStorage)
+    storage.store_url('http://no-redirect.com')
+    storage.store_metadata('http://no-redirect.com', res)
+    stored = storage.get_url(generate_hash_for('url',
+                                               'http://no-redirect.com'))
+    assert stored.get('redirect-url') is None
+    assert stored.get('redirect-status-code') is None
+    assert stored['final-url'] == 'http://no-redirect.com'
+    assert stored['final-status-code'] == '200'
+    assert stored['checked-url'] == 'http://no-redirect.com'
+    assert stored.get('url') is None
+    assert stored.get('status') is None

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -8,8 +8,8 @@ from croquemort.webhook import WebhookService
 
 def test_crawler_triggers_webhook(runner_factory, web_container_config):
     """Is crawler_container dispatching to webhook_container?"""
-    runner = runner_factory(
-        web_container_config, CrawlerService, WebhookService)
+    runner = runner_factory(web_container_config, CrawlerService,
+                            WebhookService)
     webhook_container = get_container(runner, WebhookService)
     storage_w = replace_dependencies(webhook_container, 'storage')
     dispatch = event_dispatcher(web_container_config)


### PR DESCRIPTION
Fix #1.

This a first - pretty naive - implementation of redirect handling. If there is one or more redirects when checking a URL, we store the final URL in `redirect-url` and the first redirect code in `redirect-code`.

For example, with a shortened URL:

```json
{
	"url": "https://goo.gl/ovZB",
	"status": "200",
	"updated": "2017-06-30T17:28:05.561224",
	"etag": "",
	"expires": "",
	"last-modified": "",
	"charset": "utf-8",
	"content-type": "text/html",
	"content-length": "",
	"content-disposition": "",
	"content-md5": "",
	"content-encoding": "gzip",
	"content-location": "",
	"redirect-url": "https://news.ycombinator.com/",
	"redirect-code": "301"
}
```

TODO

- [ ] README update with new format and redirect explanation
- [x] Migration of stock data

