### PR TITLE
Fix HEAD timeout handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix HEAD timeout handling [#95](https://github.com/opendatateam/croquemort/pull/95)
 
 ## 2.0.4 (2018-01-24)
 

--- a/croquemort/crawler.py
+++ b/croquemort/crawler.py
@@ -55,7 +55,9 @@ class CrawlerService(object):
                                             timeout=head_timeout)
                 except requests.exceptions.ReadTimeout:
                     # simulate 404 to trigger GET request below
-                    response = FakeResponse(status_code=404, headers={})
+                    log('Timeout on %s', url)
+                    response = FakeResponse(status_code=404, headers={},
+                                            url=url, history=[])
             # Double check for servers not dealing properly with HEAD.
             if head_offend or response.status_code in (404, 405):
                 log('Checking {url} with a GET'.format(url=url))


### PR DESCRIPTION
This PR fix the `FakeResponse()` call missing arguments in case of timeout on `HEAD`